### PR TITLE
Remove query string from submitted urls

### DIFF
--- a/AddImageUrls.module
+++ b/AddImageUrls.module
@@ -134,6 +134,10 @@ class AddImageUrls extends WireData implements Module {
 			$page->of(false);
 			foreach($urls as $url) {
 				$url = trim($url);
+				
+				// remove the query string
+				$url = strtok($url, '?');
+
 				// Break if the images field is full
 				if($remaining_uploads < 1) {
 					$this->warning( sprintf($this->_('Max file upload limit reached for field "%s".'), $field_name) );


### PR DESCRIPTION
Looks like we need to remove the query string so that urls will pass the file extension validations.